### PR TITLE
Issue 183

### DIFF
--- a/models/keypaper/visualization.py
+++ b/models/keypaper/visualization.py
@@ -320,13 +320,15 @@ class Plotter:
         min_year, max_year = self.analyzer.min_year, self.analyzer.max_year
         for c in range(n_comps):
             comp_source = self.analyzer.df[self.analyzer.df['comp'] == c]
-            ds = PlotPreprocessor.article_view_data_source(comp_source, min_year, max_year, width=700)
+            ds = PlotPreprocessor.article_view_data_source(
+                comp_source, min_year, max_year, True, width=700
+            )
             # Add type coloring
             ds.add([self.pub_types_colors_map[t] for t in comp_source['type']], 'color')
             plot = self.__serve_scatter_article_layout(source=ds,
                                                        year_range=[min_year, max_year],
                                                        title="Publications", width=760)
-            plot.circle(x='year', y='total', fill_alpha=0.5, source=ds, size='size',
+            plot.circle(x='year', y='total_fixed', fill_alpha=0.5, source=ds, size='size',
                         line_color='color', fill_color='color', legend='type')
             plot.legend.location = "top_left"
 
@@ -387,7 +389,7 @@ class Plotter:
     def top_cited_papers(self):
         min_year, max_year = self.analyzer.min_year, self.analyzer.max_year
         ds = PlotPreprocessor.article_view_data_source(
-            self.analyzer.top_cited_df, min_year, max_year, width=700
+            self.analyzer.top_cited_df, min_year, max_year, False, width=700
         )
         # Add type coloring
         ds.add([self.pub_types_colors_map[t] for t in self.analyzer.top_cited_df['type']], 'color')
@@ -397,7 +399,7 @@ class Plotter:
                                                    title=f'{len(self.analyzer.top_cited_df)} top cited papers',
                                                    width=960)
 
-        plot.circle(x='year', y='total', fill_alpha=0.5, source=ds, size='size',
+        plot.circle(x='year', y='total_fixed', fill_alpha=0.5, source=ds, size='size',
                     line_color='color', fill_color='color', legend='type')
         plot.legend.location = "top_left"
         return plot

--- a/models/test/test_visualization_data.py
+++ b/models/test/test_visualization_data.py
@@ -112,11 +112,31 @@ class TestPlotPreprocessor(unittest.TestCase):
 
         self.assertEqual(edges_found, len(edges), 'Some edges from co-citation graph are missing')
 
+    def test_article_view_data_sourceSplit(self):
+        width = 760
+        lbefore = len(set(zip(self.analyzer.df['year'], self.analyzer.df['total'])))
+        ds = PlotPreprocessor.article_view_data_source(
+            self.analyzer.df, self.analyzer.min_year, self.analyzer.max_year, True, width=width
+        )
+        lafter = len(set(zip(ds.data['year'], ds.data['total'])))
+        self.assertGreaterEqual(lafter, lbefore)
+
+        self.assertFalse(np.any(ds.data['year'] == np.nan), 'NaN values in `year` column')
+        self.assertFalse(np.any(ds.data['size'] == np.nan), 'NaN values in `size` column')
+
+        max_size = np.max(ds.data['size'])
+        max_width = max_size * (self.analyzer.max_year - self.analyzer.min_year + 1)
+        self.assertLessEqual(max_width, width, 'Horizontal overlap')
+
     def test_article_view_data_source(self):
         width = 760
+        lbefore = len(set(zip(self.analyzer.df['year'], self.analyzer.df['total'])))
         ds = PlotPreprocessor.article_view_data_source(
-            self.analyzer.df, self.analyzer.min_year, self.analyzer.max_year, width=width
+            self.analyzer.df, self.analyzer.min_year, self.analyzer.max_year, False, width=width
         )
+
+        lafter = len(set(zip(ds.data['year'], ds.data['total'])))
+        self.assertGreaterEqual(lafter, lbefore)
 
         self.assertFalse(np.any(ds.data['year'] == np.nan), 'NaN values in `year` column')
         self.assertFalse(np.any(ds.data['size'] == np.nan), 'NaN values in `size` column')


### PR DESCRIPTION
This PR contains a possible workaround to open multiple papers with the same number of citations. 
There is no limit on the number of these equally cited papers, so explicit limit can be set using MAX_AMOUNT variable in the JS code to avoid opening a lot of new tabs. Please test this behavior locally if possible.