### PR TITLE
Fix FAISS Result Sort Order in Semantic Search Service

### DIFF
--- a/pysrc/endpoints/semantic_search/semantic_search.py
+++ b/pysrc/endpoints/semantic_search/semantic_search.py
@@ -104,7 +104,7 @@ class SemanticSearch:
         for e in embeddings:
             npe = np.array(e).astype('float32').reshape(1, -1)
             ts.append(semantic_search_faiss_embedding(faiss_index, pids_idx, npe, n))
-        result = pd.concat(ts).reset_index(drop=True).sort_values(by='similarity', ascending=False)[:n]
+        result = pd.concat(ts).reset_index(drop=True).sort_values(by='similarity', ascending=True)[:n]
         return result
 
     @staticmethod
@@ -114,7 +114,7 @@ class SemanticSearch:
         df = connector.load_publications(pmids)
         df = df.merge(result, on='pmid', how='left')
         # Prioritize recent papers with the same relevance
-        df = df.sort_values(by=['similarity', 'year'], ascending=False)
+        df = df.sort_values(by=['similarity', 'year'], ascending=[True, False])
 
         # Make empty abstracts less similar
         empty_abstracts_mask = df['abstract'].isna() | (df['abstract'].str.strip() == '')

--- a/pysrc/endpoints/semantic_search/semantic_search.py
+++ b/pysrc/endpoints/semantic_search/semantic_search.py
@@ -16,7 +16,6 @@ PUBTRENDS_CONFIG = PubtrendsConfig(test=False)
 
 
 def semantic_search_faiss_embedding(faiss_index, pids_idx, query_embedding, k):
-    # Normalize embeddings if using cosine similarity
     query_embedding = l2norm(query_embedding)
 
     # Validate embedding dimension matches FAISS index

--- a/pysrc/faiss/faiss_connector.py
+++ b/pysrc/faiss/faiss_connector.py
@@ -39,7 +39,7 @@ class FaissConnector:
     def create_faiss(self):
         if self.exact:
             print('Exact search index')
-            index = faiss.IndexFlatIP(self.embeddings_dimension)
+            index = faiss.IndexFlatL2(self.embeddings_dimension)
         else:
             print('Approximate search index')
             quantizer = faiss.IndexFlatL2(self.embeddings_dimension)


### PR DESCRIPTION
Changes:
- The `similarity` column of the results is sorted in the ascending order to align with the use of L2 distance in the FAISS index. 
- The `IndexFlatIP` exact search index in the exact search configuration is replaced with the `IndexFlatL2` index.

Fixes #343